### PR TITLE
[1597] Sauvegarder de la partie dans le local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
     <div class="heading">
       <h1 class="title">1597</h1>
       <div class="scores-container">
+        <div class="restart-container restart-button">
+          <div class="restart-icon restart-icon-single"></div>
+        </div>
         <div class="score-container">0</div>
         <div class="best-container">0</div>
       </div>

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,18 +1,22 @@
-function Grid(size) {
+function Grid(size, cells) {
   this.size = size;
 
   this.cells = [];
 
-  this.build();
+  this.build(cells);
 }
 
 // Build a grid of the specified size
-Grid.prototype.build = function () {
+Grid.prototype.build = function (cells) {
   for (var x = 0; x < this.size; x++) {
     var row = this.cells[x] = [];
 
     for (var y = 0; y < this.size; y++) {
-      row.push(null);
+      if (cells && cells[x][y]) {
+        this.insertTile(new Tile({ x: x, y: y }, cells[x][y].value));
+      } else {
+        row.push(null);
+      }
     }
   }
 };

--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -68,6 +68,10 @@ KeyboardInputManager.prototype.listen = function () {
   retry.addEventListener("click", this.restart.bind(this));
   retry.addEventListener(this.eventTouchend, this.restart.bind(this));
 
+  var restart = document.querySelector(".restart-button");
+  restart.addEventListener("click", this.restart.bind(this));
+  restart.addEventListener(this.eventTouchend, this.restart.bind(this));
+
   var keepPlaying = document.querySelector(".keep-playing-button");
   keepPlaying.addEventListener("click", this.keepPlaying.bind(this));
   keepPlaying.addEventListener("touchend", this.keepPlaying.bind(this));

--- a/js/local_score_manager.js
+++ b/js/local_score_manager.js
@@ -19,8 +19,6 @@ window.fakeStorage = {
 };
 
 function LocalScoreManager() {
-  this.key     = "bestScore";
-
   var supported = this.localStorageSupported();
   this.storage = supported ? window.localStorage : window.fakeStorage;
 }
@@ -38,11 +36,10 @@ LocalScoreManager.prototype.localStorageSupported = function () {
   }
 };
 
-LocalScoreManager.prototype.get = function () {
-  return this.storage.getItem(this.key) || 0;
+LocalScoreManager.prototype.get = function (key) {
+  return JSON.parse(this.storage.getItem(key)) || 0;
 };
 
-LocalScoreManager.prototype.set = function (score) {
-  this.storage.setItem(this.key, score);
+LocalScoreManager.prototype.set = function (key, value) {
+  this.storage.setItem(key, JSON.stringify(value));
 };
-

--- a/style/main.css
+++ b/style/main.css
@@ -50,10 +50,12 @@ h1.title {
     opacity: 0; } }
 
 .scores-container {
+  display: flex;
+  gap: 10px;
   float: right;
   text-align: right; }
 
-.score-container, .best-container {
+.score-container, .best-container, .restart-container {
   position: relative;
   display: inline-block;
   background: #bbada0;
@@ -349,6 +351,9 @@ hr {
     color: #f9f6f2;
     background: #f65e3b;
     font-size: 45px; }
+@media screen and (max-width: 520px) {
+  .tile.tile-144 .tile-inner {
+    font-size: 25px; } }
   .tile.tile-233 .tile-inner {
     color: #f9f6f2;
     background: #edcc72;
@@ -564,17 +569,26 @@ hr {
     padding: 0 20px; }
 
   h1.title {
-    font-size: 27px;
+    font-size: 25px;
     margin-top: 15px; }
 
   .container {
     width: 280px;
     margin: 0 auto; }
 
-  .score-container, .best-container {
+  .scores-container {
+    gap: 6px
+  }
+
+  .score-container, .best-container, .restart-container {
     margin-top: 0;
-    padding: 15px 10px;
-    min-width: 40px; }
+    padding: 12px 10px;
+    min-width: 40px;
+    font-size: 18px }
+
+  .score-container:after, .best-container:after {
+    top: 8px;
+  }
 
   .heading {
     margin-bottom: 10px; }
@@ -749,3 +763,55 @@ hr {
     margin-top: 90px !important; }
   .game-message .lower {
     margin-top: 30px !important; } }
+
+div.restart-icon {
+  position: relative;
+  transform: rotate(90deg);
+}
+
+div.restart-container {
+  padding: 12px 14px 18px 12px;
+}
+
+div.restart-container:hover {
+  cursor: pointer;
+}
+
+.restart-icon-single:before, .restart-icon-single:after {
+  content: '';
+  display: block;
+}
+.restart-icon-single:before {
+  border-color: transparent white white white;
+  border-radius: 50%;
+  border-style: solid;
+  border-width: .18em;
+  height: 1em;
+  width: 1em;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+.restart-icon-single:after {
+  border-color: transparent transparent transparent white;
+  border-style: solid;
+  border-width: .25em 0 .25em .40em;
+  height: 0;
+  position: absolute;
+  top: -4px;
+  left: 48%;
+  width: 0;
+}
+
+@media screen and (max-width: 520px) {
+  div.restart-container {
+    padding: 16px 8px 8px 7px;
+  }
+  .restart-icon-single:before {
+    height: 1.25em;
+    width: 1.25em;
+  }
+  .restart-icon-single:after {
+    left: 14px;
+    top: -3px;
+  }
+}


### PR DESCRIPTION
Actuellement, le local storage du navigateur stocke uniquement le meilleur score.
Ce ticket et la MR associée permettent de sauvegarder, en plus, dans le local storage, la partie en cours.

Cas de tests à développer :
- **première connexion** => la partie se lance normalement avec 2 tuiles
- **rafraichissement avant victoire** => la partie reprend là où elle avait été arrêtée
- **rafraichissement pendant écran de défaite** => l'écran de défaite est sauvegardé, il continue d'apparaitre tant que l'utilisateur ne clique pas sûr "Essayer encore"
- **rafraichissement seconde partie** => même comportement que "rafraichissement avant victoire"
- **rafraichissement écran de victoire** => l'écran de victoire réapparait jusqu'à ce qu'un choix soit fait
- **rafraichissement écran de victoire, puis clic sur nouvelle partie** => même comportement que "rafraichissement avant victoire", l'écran de victoire réapparait si la partie est de nouveau gagnée
- **rafraichissement écran de victoire, puis clic sur continuer** => même comportement que "rafraichissement avant victoire", l'écran de victoire ne réapparait plus
- **rafraichissement écran de victoire, puis clic sur le bouton de redémarrage de partie** => même comportement que "rafraichissement avant victoire", l'écran de victoire réapparait si la partie est de nouveau gagnée

Initialement, l'utilisateur pouvait redémarrer sa partie à tout moment en rechargeant la page. Ce n'est plus le cas. Pour palier à ce problème, un bouton pour redémarrer la partie doit être ajouté.

Ce développement corrige aussi un problème d'affichage sur la tuile 144 en mobile (la police est trop grosse et le contenu sort de la tuile).